### PR TITLE
Try using test interface to add agents instead

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -59,7 +59,7 @@ class ConductorHandle {
     ///         For test agents only. NOT SECURE!
     ///     Returns the agent public key
 
-    return this.callAdmin('admin/agent/add')({ id: this.agentId, name: this.agentName, passphrase: "eh?" })
+    return this.callAdmin('test/agent/add')({ id: this.agentId, name: this.agentName })
   }
 
   async createDnaInstance(instanceId, dnaPath) {


### PR DESCRIPTION
I'm not sure if this will work but it might be worth a shot. This adds an agent using the new `test/agent/add` RPC function which results in something identical to when we were creating agents using the Node conductor.